### PR TITLE
Update human-readable name of the module

### DIFF
--- a/stanford_publication.info
+++ b/stanford_publication.info
@@ -1,4 +1,4 @@
-name = Publication
+name = Stanford Publication
 description = Publication content type, vocabulary, and Views
 core = 7.x
 package = Stanford


### PR DESCRIPTION
Human-readable name of the module (not the content type) should be "Stanford Publication," yeah?