### PR TITLE
D8CORE-3445: tweaking the label names and hiding extra fields

### DIFF
--- a/config/install/core.entity_view_display.citation.su_article_journal.default.yml
+++ b/config/install/core.entity_view_display.citation.su_article_journal.default.yml
@@ -75,7 +75,7 @@ content:
     region: content
   su_publisher:
     type: string
-    weight: 4
+    weight: 1
     region: content
     label: above
     settings:

--- a/config/install/core.entity_view_display.citation.su_article_journal.default.yml
+++ b/config/install/core.entity_view_display.citation.su_article_journal.default.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.citation.su_article_journal.su_year
     - stanford_publication.citation_type.su_article_journal
   module:
+    - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_article_journal.default
 targetEntityType: citation
@@ -37,6 +37,8 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
+      ds:
+        ds_limit: ''
     type: name_default
     region: content
   su_day:
@@ -60,17 +62,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_issue:
-    weight: 6
-    label: above
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: number_integer
-    region: content
   su_month:
     weight: 2
     label: above
@@ -82,16 +73,6 @@ content:
         class: su-margin-bottom-2
     type: number_integer
     region: content
-  su_page:
-    weight: 7
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_publisher:
     type: string
     weight: 4
@@ -102,28 +83,6 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
-  su_url:
-    weight: 9
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
-  su_volume:
-    weight: 5
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_year:
     weight: 1
     label: above
@@ -136,4 +95,8 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_issue: true
+  su_page: true
+  su_url: true
+  su_volume: true
   title: true

--- a/config/install/core.entity_view_display.citation.su_article_newspaper.default.yml
+++ b/config/install/core.entity_view_display.citation.su_article_newspaper.default.yml
@@ -10,9 +10,8 @@ dependencies:
     - field.field.citation.su_article_newspaper.su_year
     - stanford_publication.citation_type.su_article_newspaper
   module:
-
+    - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_article_newspaper.default
 targetEntityType: citation
@@ -34,6 +33,8 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
+      ds:
+        ds_limit: ''
     type: name_default
     region: content
   su_day:
@@ -68,20 +69,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_url:
-    weight: 5
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: '0'
-      target: '0'
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: link
-    region: content
   su_year:
     weight: 4
     label: above
@@ -94,4 +81,5 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_url: true
   title: true

--- a/config/install/core.entity_view_display.citation.su_book.default.yml
+++ b/config/install/core.entity_view_display.citation.su_book.default.yml
@@ -13,8 +13,8 @@ dependencies:
     - field.field.citation.su_book.su_year
     - stanford_publication.citation_type.su_book
   module:
+    - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_book.default
 targetEntityType: citation
@@ -44,6 +44,8 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
+      ds:
+        ds_limit: ''
     type: name_default
     region: content
   su_doi:
@@ -56,69 +58,16 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_edition:
-    weight: 3
-    label: above
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: number_integer
-    region: content
-  su_page:
-    weight: 6
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_publisher:
-    weight: 5
+    type: string
+    weight: 0
+    region: content
     label: above
     settings:
       link_to_entity: false
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
-    type: string
-    region: content
-  su_publisher_place:
-    weight: 4
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
-  su_subtitle:
-    weight: 1
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
-  su_url:
-    weight: 8
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
   su_year:
     weight: 2
     label: above
@@ -131,4 +80,9 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_edition: true
+  su_page: true
+  su_publisher_place: true
+  su_subtitle: true
+  su_url: true
   title: true

--- a/config/install/core.entity_view_display.citation.su_thesis.default.yml
+++ b/config/install/core.entity_view_display.citation.su_thesis.default.yml
@@ -72,7 +72,7 @@ content:
     type: number_integer
     region: content
   su_publisher:
-    weight: 5
+    weight: 1
     label: above
     settings:
       link_to_entity: false

--- a/config/install/core.entity_view_display.citation.su_thesis.default.yml
+++ b/config/install/core.entity_view_display.citation.su_thesis.default.yml
@@ -12,8 +12,8 @@ dependencies:
     - field.field.citation.su_thesis.su_year
     - stanford_publication.citation_type.su_thesis
   module:
+    - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_thesis.default
 targetEntityType: citation
@@ -35,6 +35,8 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
+      ds:
+        ds_limit: ''
     type: name_default
     region: content
   su_day:
@@ -50,16 +52,6 @@ content:
     region: content
   su_doi:
     weight: 6
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
-  su_genre:
-    weight: 4
     label: above
     settings:
       link_to_entity: false
@@ -89,18 +81,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_url:
-    weight: 7
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
   su_year:
     weight: 3
     label: above
@@ -113,4 +93,6 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_genre: true
+  su_url: true
   title: true

--- a/config/install/field.field.citation.su_article_journal.su_publisher.yml
+++ b/config/install/field.field.citation.su_article_journal.su_publisher.yml
@@ -8,7 +8,7 @@ id: citation.su_article_journal.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_article_journal
-label: 'Journal Name'
+label: Publisher
 description: ''
 required: false
 translatable: false

--- a/config/install/field.field.citation.su_article_newspaper.su_publisher.yml
+++ b/config/install/field.field.citation.su_article_newspaper.su_publisher.yml
@@ -8,7 +8,7 @@ id: citation.su_article_newspaper.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_article_newspaper
-label: 'Newspaper Title'
+label: Publisher
 description: ''
 required: false
 translatable: false

--- a/config/install/field.field.citation.su_thesis.su_publisher.yml
+++ b/config/install/field.field.citation.su_thesis.su_publisher.yml
@@ -8,7 +8,7 @@ id: citation.su_thesis.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_thesis
-label: 'University Name'
+label: Publisher
 description: ''
 required: false
 translatable: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the su-publisher on all the types to be "Publisher"
- Hid some of the fields 

# Needed By (Date)
- 2/4

# Urgency
- high

# Steps to Test

1. Pull in this change.
2. import the profile configs.
3. Verify on the publication node that the publisher says "Publisher" for all the types. 
4. Verify the publisher always comes before the date 

# Affected Projects or Products
- Publication module

# Associated Issues and/or People
- D8CORE-3445
- https://github.com/SU-SWS/stanford_profile/pull/353

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
