### PR TITLE
D8CORE-4174 Allow users to choose the citation format for the entire site

### DIFF
--- a/stanford_publication.install
+++ b/stanford_publication.install
@@ -20,6 +20,13 @@ function stanford_publication_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function stanford_publication_uninstall() {
+  \Drupal::state()->delete('stanford_publication.citation_format');
+}
+
+/**
  * Create the 'All' publication topic term.
  */
 function stanford_publication_update_8001() {

--- a/stanford_publication.module
+++ b/stanford_publication.module
@@ -5,11 +5,13 @@
  * stanford_publication.module
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
+use Drupal\stanford_publication\Entity\CitationInterface;
 use Drupal\views\ViewExecutable;
 use Symfony\Component\Finder\Finder;
 
@@ -81,6 +83,51 @@ function stanford_publication_entity_view(array &$build, EntityInterface $entity
       '#type' => 'markup',
       '#markup' => $citation_type,
     ];
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_publication_form_taxonomy_overview_terms_alter(&$form, FormStateInterface $form_state) {
+  if ($form_state->get('taxonomy')['vocabulary']->id() == 'stanford_publication_topics') {
+    $form['citation_format'] = [
+      '#type' => 'select',
+      '#title' => t('Citation Format'),
+      '#options' => [
+        'apa' => 'APA',
+        'chicago' => t('Chicago'),
+      ],
+      '#default_value' => \Drupal::state()->get('stanford_publication.citation_format', 'chicago'),
+    ];
+    $form['#submit'][] = '_stanford_publication_term_overview_submit';
+  }
+}
+
+/**
+ * Taxonomy term overview form submit to save the citation format value.
+ *
+ * @param array $form
+ *   Complete form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Submitted form state.
+ */
+function _stanford_publication_term_overview_submit(array $form, FormStateInterface $form_state) {
+  $state = \Drupal::state();
+  if ($state->get('stanford_publication.citation_format') != $form_state->getValue('citation_format')) {
+    $state->set('stanford_publication.citation_format', $form_state->getValue('citation_format'));
+    Cache::invalidateTags(['citation_view']);
+  }
+}
+
+/**
+ * Implements hook_entity_view_mode_alter().
+ */
+function stanford_publication_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {
+  if ($entity instanceof CitationInterface) {
+    // Change the view mode to what the user chose in the term overview page.
+    $view_mode = \Drupal::state()
+      ->get('stanford_publication.citation_format', $view_mode);
   }
 }
 

--- a/stanford_publication.module
+++ b/stanford_publication.module
@@ -124,8 +124,12 @@ function _stanford_publication_term_overview_submit(array $form, FormStateInterf
  * Implements hook_entity_view_mode_alter().
  */
 function stanford_publication_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {
-  if ($entity instanceof CitationInterface) {
-    // Change the view mode to what the user chose in the term overview page.
+  if (
+    $entity instanceof CitationInterface &&
+    \Drupal::routeMatch()->getRouteName() == 'entity.taxonomy_term.canonical'
+  ) {
+    // Change the view mode on taxonomy term pages to what the user chose in the
+    // term overview page.
     $view_mode = \Drupal::state()
       ->get('stanford_publication.citation_format', $view_mode);
   }

--- a/stanford_publication.module
+++ b/stanford_publication.module
@@ -94,6 +94,7 @@ function stanford_publication_form_taxonomy_overview_terms_alter(&$form, FormSta
     $form['citation_format'] = [
       '#type' => 'select',
       '#title' => t('Citation Format'),
+      '#description' => t('Change the citation format for the publication items displayed on the taxonomy pages.'),
       '#options' => [
         'apa' => 'APA',
         'chicago' => t('Chicago'),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow a user to change the citation format on the taxonomy pages

# Need Review By (Date)
- 11/19

# Urgency
- high

# Steps to Test
1. Checkout this branch
2. clear caches
3. create a publication using one of the taxonomy terms
4. View the taxonomy term page and keep that page in another tab/browser
5. Open a new tab/browser & go to `/admin/structure/taxonomy/manage/stanford_publication_topics/overview` and choose `APA` format
6. view the same term page above
7. verify the format has changed from the one in step 4.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

